### PR TITLE
the MAE computation on the test set is corrected

### DIFF
--- a/model_training_notebook.ipynb
+++ b/model_training_notebook.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
     "\n",
     "# define files to be used\n",
     "global DATA_PATH \n",
-    "DATA_PATH = './sp_dataset/marked_training_data/'"
+    "DATA_PATH = './sp_dataset/marked_data/'"
    ]
   },
   {
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,17 +328,15 @@
     "                predictions.append(logits)\n",
     "                true_labels.append(label_ids)\n",
     "            # calculate errors\n",
-    "            total_distance = 0\n",
     "            distance_records = []\n",
     "            for i in range(len(predictions)):\n",
     "                for j in range(len(predictions[i])):\n",
     "                    distance = abs(predictions[i][j] - true_labels[i][j])\n",
-    "                    total_distance += distance\n",
     "                    distance_records.append(distance)\n",
     "\n",
-    "            total_data_point = len(predictions) * len(predictions[0])\n",
-    "\n",
-    "            MAE = total_distance / total_data_point\n",
+    "            ## MAE = mean value of all absolute errors (stored in distance_records)\n",
+    "            MAE = np.mean(np.array(distance_records)) \n",
+    "            ## MdAE = median value of all absolute errors (stored in distance_records)\n",
     "            MdAE = np.median(np.array(distance_records)) \n",
     "\n",
     "            MAE_RECORDS.append(MAE)\n",
@@ -570,13 +568,10 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "aeb9b208553ed88b6b603c645b036ca8f07699d154de6af90b2d9b928ffaf5e4"
-  },
   "kernelspec": {
-   "display_name": "Python (hf_xfmr)",
+   "display_name": "Python 3.7.13 ('GPT2SP')",
    "language": "python",
-   "name": "hf_xfmr"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -588,7 +583,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.7.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "95502c86ed2e8b82df6e58f8450b4387aca3c902602792f25ea2aa6818e861bc"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
To compute the MAE on the test set, the Sum of Absolute Errors (SAE) is divided by 'total_data_point', which is computed as the number of the batches in the test set multiplied by the length of the first batch. This computation always produces a number greater than the actual size of the test set. In fact, considering the current initialisation of variables in the code (i.e., `DYNAMIC_BATCH = True` and `BATCH_SIZE_RATIO = 0.3` for within project estimation), the 'total_data_point' is almost two times the size of the test set. To correct this, I applied `np.mean()` on the list of the absolute errors (i.e., `distance_records`).